### PR TITLE
[website_coupon] Add a relation field to voucher to point to a gift product

### DIFF
--- a/website_coupon/controllers/main.py
+++ b/website_coupon/controllers/main.py
@@ -61,8 +61,7 @@ class WebsiteCoupon(http.Controller):
             return request.redirect(base_url + '?coupon_not_available=1')
 
         order = request.website.sale_get_order(force_create=1)
-        gift_product = request.env['product.product'].sudo().search(
-            [('name', '=', 'Gift Coupon')], limit=1)
+        gift_product = coupon.voucher.gift_product_id
 
         # Make sure the gift product is not already in current order
         if any(True for line in order.order_line

--- a/website_coupon/models/gift_voucher.py
+++ b/website_coupon/models/gift_voucher.py
@@ -48,6 +48,9 @@ class GiftVoucher(models.Model):
     min_value = fields.Integer(string="Minimum Voucher Value", required=True)
     max_value = fields.Integer(string="Maximum Voucher Value", required=True)
     expiry_date = fields.Date(string="Expiry Date", required=True)
+    gift_product_id = fields.Many2one(
+        'product.product', string="Product", required=True,
+        default=lambda self: self.env.ref('website_coupon.discount_product'))
 
     def is_order_line_eligible(self, order_line):
         if self.voucher_type == 'product':


### PR DESCRIPTION
This way, the gift product will not be selected by name anymore, which
is not reliable, and it can be adapted to each voucher (notably its
description, image, etc.).
The default value is the inserted gift product, so there is no
regression introduced by this commit.